### PR TITLE
Disabling 'initOptions' from FoamFix, to ensure DefaultOptions work.

### DIFF
--- a/overrides/config/foamfix.cfg
+++ b/overrides/config/foamfix.cfg
@@ -17,7 +17,7 @@ client {
     B:disableTextureAnimations=false
 
     # Initialize the options.txt and forge.cfg files with rendering performance-friendly defaults if not present. [default: true]
-    B:initOptions=true
+    B:initOptions=false
 
     # Makes vanilla creative tab search use JEI's lookups - saves a lot of RAM *and* gives you fancy JEI features! [default: true]
     B:jeiCreativeSearch=true


### PR DESCRIPTION
As stated at the beginning of [Default Options CurseForge page](https://minecraft.curseforge.com/projects/default-options):

> If you are using FoamFix Anarchy Version, disable B:initOptions in the FoamFix config or else Default Options will not work.

This PR simply sets B:initOptions to false.

According to [FoamFix documentation](https://unascribed.com/b/2017-17-10-so-heres-how-foamfix-works.html) what this setting does is:

> If enabled, every time the game starts, FoamFix will set `alwaysSetupTerrainOffThread` in forge.cfg to true and turn off `mipmapping`.

This is already true for the default settings in ATM3.