### PR TITLE
Fixed GitHub menu link

### DIFF
--- a/overrides/config/CustomMainMenu/mainmenu.json
+++ b/overrides/config/CustomMainMenu/mainmenu.json
@@ -130,7 +130,7 @@
             "action" :  
             {
                 "type" : "openLink",
-                "link" : "https://github.com/AllTheMods/ATM-3"
+                "link" : "https://github.com/AllTheMods/ATM3-Remix"
             }
         },
 


### PR DESCRIPTION
This fixes the GitHub link in the main menu to point to the correct repository