### PR TITLE
EnderIO Compatibility and Charged Certus>Certus

### DIFF
--- a/overrides/scripts/balance/atm_packmodes_simplified_fixes.zs
+++ b/overrides/scripts/balance/atm_packmodes_simplified_fixes.zs
@@ -65,6 +65,3 @@ print(" ======================================================== ");
 	Grinder.addRecipe(<enderio:item_material:36>, <enderio:item_material:14>, 4);
 	Grinder.addRecipe(<enderio:item_material:37>, <enderio:item_material:16>, 4);
 	Grinder.addRecipe(<enderio:item_material:34>, <enderio:item_material:19>, 4);
-//====== Charged Certus Quartz Crystal > Certus Quartz Crystal ======
-    recipes.remove(<jaopca:item_nuggetchargedcertusquartz>);
-	recipes.addShapeless("Charged Certus>Certus", <appliedenergistics2:material>, [<appliedenergistics2:material:1>]);

--- a/overrides/scripts/balance/atm_packmodes_simplified_fixes.zs
+++ b/overrides/scripts/balance/atm_packmodes_simplified_fixes.zs
@@ -2,9 +2,6 @@ import crafttweaker.item.IIngredient;
 import crafttweaker.item.IItemStack;
 import crafttweaker.oredict.IOreDict;
 import crafttweaker.oredict.IOreDictEntry;
-import mods.thermalexpansion.Pulverizer;
-import mods.extrautils2.Crusher;
-import mods.appliedenergistics2.Grinder;
 
 #packmode simplified
 

--- a/overrides/scripts/balance/atm_packmodes_simplified_fixes.zs
+++ b/overrides/scripts/balance/atm_packmodes_simplified_fixes.zs
@@ -2,6 +2,9 @@ import crafttweaker.item.IIngredient;
 import crafttweaker.item.IItemStack;
 import crafttweaker.oredict.IOreDict;
 import crafttweaker.oredict.IOreDictEntry;
+import mods.thermalexpansion.Pulverizer;
+import mods.extrautils2.Crusher;
+import mods.appliedenergistics2.Grinder;
 
 #packmode simplified
 
@@ -35,3 +38,33 @@ print(" ======================================================== ");
 		RoyalJelly,
 		AAFert, IFFert, TFFert, ManaPowder,
 		100000, 1200, [0.0, 0.6, 0.1]);	
+
+//====== EnderIO Compatibility =====
+//
+    //Pulverizer
+	mods.thermalexpansion.Pulverizer.addRecipe(<enderio:item_material:36>, <enderio:item_material:14>, 2000);
+	mods.thermalexpansion.Pulverizer.addRecipe(<enderio:item_material:37>, <enderio:item_material:16>, 2000);
+	mods.thermalexpansion.Pulverizer.addRecipe(<enderio:item_material:34>, <enderio:item_material:19>, 2000);
+	//EX2 Crusher
+	mods.extrautils2.Crusher.add(<enderio:item_material:36>, <enderio:item_material:14>);
+	mods.extrautils2.Crusher.add(<enderio:item_material:37>, <enderio:item_material:16>);
+	mods.extrautils2.Crusher.add(<enderio:item_material:34>, <enderio:item_material:19>);
+	//AA Crusher
+	mods.actuallyadditions.Crusher.addRecipe(<enderio:item_material:36>, <enderio:item_material:14>);
+	mods.actuallyadditions.Crusher.addRecipe(<enderio:item_material:37>, <enderio:item_material:16>);
+	mods.actuallyadditions.Crusher.addRecipe(<enderio:item_material:34>, <enderio:item_material:19>);
+	//Mekanism Crusher
+	mods.mekanism.crusher.addRecipe(<enderio:item_material:14>, <enderio:item_material:36>);
+	mods.mekanism.crusher.addRecipe(<enderio:item_material:16>, <enderio:item_material:37>);
+	mods.mekanism.crusher.addRecipe(<enderio:item_material:19>, <enderio:item_material:34>);
+	//IE Crusher
+	mods.immersiveengineering.Crusher.addRecipe(<enderio:item_material:36>, <enderio:item_material:14>, 2048);
+	mods.immersiveengineering.Crusher.addRecipe(<enderio:item_material:37>, <enderio:item_material:16>, 2048);
+	mods.immersiveengineering.Crusher.addRecipe(<enderio:item_material:34>, <enderio:item_material:19>, 2048);
+	//AE2 GrindStone
+	Grinder.addRecipe(<enderio:item_material:36>, <enderio:item_material:14>, 4);
+	Grinder.addRecipe(<enderio:item_material:37>, <enderio:item_material:16>, 4);
+	Grinder.addRecipe(<enderio:item_material:34>, <enderio:item_material:19>, 4);
+//====== Charged Certus Quartz Crystal > Certus Quartz Crystal ======
+    recipes.remove(<jaopca:item_nuggetchargedcertusquartz>);
+	recipes.addShapeless("Charged Certus>Certus", <appliedenergistics2:material>, [<appliedenergistics2:material:1>]);

--- a/overrides/scripts/balance/atm_packmodes_simplified_fixes.zs
+++ b/overrides/scripts/balance/atm_packmodes_simplified_fixes.zs
@@ -2,6 +2,9 @@ import crafttweaker.item.IIngredient;
 import crafttweaker.item.IItemStack;
 import crafttweaker.oredict.IOreDict;
 import crafttweaker.oredict.IOreDictEntry;
+import mods.thermalexpansion.Pulverizer;
+import mods.extrautils2.Crusher;
+import mods.appliedenergistics2.Grinder;
 
 #packmode simplified
 

--- a/overrides/scripts/general/atm_general_misc.zs
+++ b/overrides/scripts/general/atm_general_misc.zs
@@ -492,33 +492,3 @@ recipes.remove(<minecraft:chest>);
 //
 	// Once mod is updated this can be pulled
 	mods.jei.JEI.removeAndHide(<hooked:hook:3>,false);
-
-//====== EnderIO Compatibility =====
-//
-    //Pulverizer
-	mods.thermalexpansion.Pulverizer.addRecipe(<enderio:item_material:36>, <enderio:item_material:14>, 2000);
-	mods.thermalexpansion.Pulverizer.addRecipe(<enderio:item_material:37>, <enderio:item_material:16>, 2000);
-	mods.thermalexpansion.Pulverizer.addRecipe(<enderio:item_material:34>, <enderio:item_material:19>, 2000);
-	//EX2 Crusher
-	mods.extrautils2.Crusher.add(<enderio:item_material:36>, <enderio:item_material:14>);
-	mods.extrautils2.Crusher.add(<enderio:item_material:37>, <enderio:item_material:16>);
-	mods.extrautils2.Crusher.add(<enderio:item_material:34>, <enderio:item_material:19>);
-	//AA Crusher
-	mods.actuallyadditions.Crusher.addRecipe(<enderio:item_material:36>, <enderio:item_material:14>);
-	mods.actuallyadditions.Crusher.addRecipe(<enderio:item_material:37>, <enderio:item_material:16>);
-	mods.actuallyadditions.Crusher.addRecipe(<enderio:item_material:34>, <enderio:item_material:19>);
-	//Mekanism Crusher
-	mods.mekanism.crusher.addRecipe(<enderio:item_material:14>, <enderio:item_material:36>);
-	mods.mekanism.crusher.addRecipe(<enderio:item_material:16>, <enderio:item_material:37>);
-	mods.mekanism.crusher.addRecipe(<enderio:item_material:19>, <enderio:item_material:34>);
-	//IE Crusher
-	mods.immersiveengineering.Crusher.addRecipe(<enderio:item_material:36>, <enderio:item_material:14>, 2048);
-	mods.immersiveengineering.Crusher.addRecipe(<enderio:item_material:37>, <enderio:item_material:16>, 2048);
-	mods.immersiveengineering.Crusher.addRecipe(<enderio:item_material:34>, <enderio:item_material:19>, 2048);
-	//AE2 GrindStone
-	Grinder.addRecipe(<enderio:item_material:36>, <enderio:item_material:14>, 4);
-	Grinder.addRecipe(<enderio:item_material:37>, <enderio:item_material:16>, 4);
-	Grinder.addRecipe(<enderio:item_material:34>, <enderio:item_material:19>, 4);
-//====== Charged Certus Quartz Crystal > Certus Quartz Crystal ======
-    recipes.remove(<jaopca:item_nuggetchargedcertusquartz>);
-	recipes.addShapeless("Charged Certus>Certus", <appliedenergistics2:material>, [<appliedenergistics2:material:1>]);

--- a/overrides/scripts/general/atm_general_misc.zs
+++ b/overrides/scripts/general/atm_general_misc.zs
@@ -492,3 +492,33 @@ recipes.remove(<minecraft:chest>);
 //
 	// Once mod is updated this can be pulled
 	mods.jei.JEI.removeAndHide(<hooked:hook:3>,false);
+
+//====== EnderIO Compatibility =====
+//
+    //Pulverizer
+	mods.thermalexpansion.Pulverizer.addRecipe(<enderio:item_material:36>, <enderio:item_material:14>, 2000);
+	mods.thermalexpansion.Pulverizer.addRecipe(<enderio:item_material:37>, <enderio:item_material:16>, 2000);
+	mods.thermalexpansion.Pulverizer.addRecipe(<enderio:item_material:34>, <enderio:item_material:19>, 2000);
+	//EX2 Crusher
+	mods.extrautils2.Crusher.add(<enderio:item_material:36>, <enderio:item_material:14>);
+	mods.extrautils2.Crusher.add(<enderio:item_material:37>, <enderio:item_material:16>);
+	mods.extrautils2.Crusher.add(<enderio:item_material:34>, <enderio:item_material:19>);
+	//AA Crusher
+	mods.actuallyadditions.Crusher.addRecipe(<enderio:item_material:36>, <enderio:item_material:14>);
+	mods.actuallyadditions.Crusher.addRecipe(<enderio:item_material:37>, <enderio:item_material:16>);
+	mods.actuallyadditions.Crusher.addRecipe(<enderio:item_material:34>, <enderio:item_material:19>);
+	//Mekanism Crusher
+	mods.mekanism.crusher.addRecipe(<enderio:item_material:14>, <enderio:item_material:36>);
+	mods.mekanism.crusher.addRecipe(<enderio:item_material:16>, <enderio:item_material:37>);
+	mods.mekanism.crusher.addRecipe(<enderio:item_material:19>, <enderio:item_material:34>);
+	//IE Crusher
+	mods.immersiveengineering.Crusher.addRecipe(<enderio:item_material:36>, <enderio:item_material:14>, 2048);
+	mods.immersiveengineering.Crusher.addRecipe(<enderio:item_material:37>, <enderio:item_material:16>, 2048);
+	mods.immersiveengineering.Crusher.addRecipe(<enderio:item_material:34>, <enderio:item_material:19>, 2048);
+	//AE2 GrindStone
+	Grinder.addRecipe(<enderio:item_material:36>, <enderio:item_material:14>, 4);
+	Grinder.addRecipe(<enderio:item_material:37>, <enderio:item_material:16>, 4);
+	Grinder.addRecipe(<enderio:item_material:34>, <enderio:item_material:19>, 4);
+//====== Charged Certus Quartz Crystal > Certus Quartz Crystal ======
+    recipes.remove(<jaopca:item_nuggetchargedcertusquartz>);
+	recipes.addShapeless("Charged Certus>Certus", <appliedenergistics2:material>, [<appliedenergistics2:material:1>]);


### PR DESCRIPTION
EnderIO crystals is only pulverized in the SAG Mill and this is really sad, i added the compatibility.
When you convert too many Certus Quartz to Charged Certus Quartz and you realize that you don't need all that amount...
Let's give him a chance to fix it.
I want too add Sheldonite to the Deep Dark with a little more of chances to generate (In The End it have only 0.05), if you don't know, you can get Platinum (TE) from it; but i need enable the option "ReplaceStandardGeneration" in the COFH World Config to do it. What's you opnion? should i made it?