### PR TITLE
Add a number of missing seeds to the Forester's Backpack.

### DIFF
--- a/overrides/config/forestry/backpacks.cfg
+++ b/overrides/config/forestry/backpacks.cfg
@@ -100,10 +100,21 @@ backpacks {
                 minecraft:yellow_flower:0
                 evilcraft:undead_log
                 integrateddynamics:menril_log
+                plants2:ambrosia_a
+                plants2:apocynum_c
+                plants2:akebia_q
+                plants2:amarthus_h_seeds
+                plants2:okra_seeds
+                plants2:pineapple_seeds
+                thebetweenlands:middle_fruit_bush_seeds
+                thebetweenlands:aspectrus_seeds
+                extrautils2:redorchid
+                extrautils2:enderlily
              >
 
             # Add itemStacks for the forestry.forester's backpack here in the format 'modid:name:meta'. For wildcard metadata the format is 'modid:name'.
             S:item.stacks.rejected <
+                embers:seed
              >
 
             # Add ore dictionary names for the forestry.forester's backpack here in the format 'oreDictName'. Regular expressions may also be used.
@@ -113,6 +124,7 @@ backpacks {
                 logWood
                 saplingTree
                 seed[A-Z].*
+                listAllSeed
                 stickWood
                 sugarcane
                 treeSapling

--- a/overrides/config/forestry/backpacks.cfg
+++ b/overrides/config/forestry/backpacks.cfg
@@ -103,7 +103,7 @@ backpacks {
                 plants2:ambrosia_a
                 plants2:apocynum_c
                 plants2:akebia_q
-                plants2:amarthus_h_seeds
+                plants2:amaranthus_h_seeds
                 plants2:okra_seeds
                 plants2:pineapple_seeds
                 thebetweenlands:middle_fruit_bush_seeds


### PR DESCRIPTION
Specifically, adds the following:

- OreDict listAllSeed

- ExtraUtils 2 Ender Lily and Red Orchid

- Various Plants seeds

- Seeds from The Betweenlands

This change also blacklists the following items:

- The crystal seeds from Embers, as they are not used in farming.

Should address #112.