### PR TITLE
Disable Minecolonies Protection

### DIFF
--- a/overrides/config/minecolonies.cfg
+++ b/overrides/config/minecolonies.cfg
@@ -115,7 +115,7 @@ general {
         B:doBarbariansSpawn=true
 
         # Should the colony protection be enabled?
-        B:enableColonyProtection=true
+        B:enableColonyProtection=false
 
         # Should in development features be enabled (might be buggy)
         B:enableInDevelopmentFeatures=false


### PR DESCRIPTION
Redundant with ftbu, also prevents fake users from working correctly and blocks admin access.