### PR TITLE
Add Cheese to the foodCheese oredict

### DIFF
--- a/overrides/scripts/oredict/atm_oredict_misc.zs
+++ b/overrides/scripts/oredict/atm_oredict_misc.zs
@@ -147,4 +147,10 @@ Anything regarding oredict that doesn't need it's own dedicated script file
 //
    recipes.addShapeless(<ic2:ingot>, [<techreborn:ingot:21>]);
    <ore:ingotMixedMetal>.add(<ic2:ingot>);
+
+//====== Food ======
+//
+
+	<ore:foodCheese>.add(<actuallyadditions:item_food:0>);
+
    


### PR DESCRIPTION
Cheese's should be compatible across mods between AA, Bird's Foods and XL food mod. This allows it.