### PR TITLE
Add biotite to worldgen.

### DIFF
--- a/overrides/config/quark.cfg
+++ b/overrides/config/quark.cfg
@@ -1833,12 +1833,12 @@ world {
     }
 
     biotite {
-        I:"Cluster count for natural generation"=16
+        I:"Cluster count for natural generation"=1
         I:"Cluster size"=14
         I:"Clusters generated per dragon death tick"=16
         B:"Enable walls"=true
-        B:"Generate by dragon kill"=true
-        B:"Generate naturally"=false
+        B:"Generate by dragon kill"=false
+        B:"Generate naturally"=true
         I:"Generation delay on dragon death"=1
     }
 


### PR DESCRIPTION
Adds biotite to end worldgen. About as common as draconium.
Also disables it from spaning whenever the dragon is killed.