### PR TITLE
Blacklist Tinkers Slime Islands from spawning in Spectre Key Dimension

### DIFF
--- a/overrides/config/tconstruct.cfg
+++ b/overrides/config/tconstruct.cfg
@@ -157,6 +157,7 @@ worldgen {
         144
         418
         4598
+		-343800852
      >
 
     # If true, slime islands wont generate in dimensions which aren't of type surface. This means they wont generate in modded cave dimensions like the deep dark.


### PR DESCRIPTION
The Specter Dimension (accessed by the specter key) should no longer have unreachable slime islands in the distance beyond the boundaries of the specter room.